### PR TITLE
Remove usage of WMenu deprecated methods from examples

### DIFF
--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/FilterableTableExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/table/FilterableTableExample.java
@@ -430,22 +430,22 @@ public final class FilterableTableExample extends WContainer {
 			}
 
 			List<WComponent> selectedItems = new ArrayList<>();
-			List<WComponent> menuSelectedItems;
+			List<MenuItemSelectable> menuSelectedItems;
 
 			if (firstNameFilterMenu.isVisible()) {
-				menuSelectedItems = firstNameFilterMenu.getSelectedItems();
+				menuSelectedItems = firstNameFilterMenu.getSelectedMenuItems();
 				if (menuSelectedItems != null && !menuSelectedItems.isEmpty()) {
 					selectedItems.addAll(menuSelectedItems);
 				}
 			}
 			if (lastNameFilterMenu.isVisible()) {
-				menuSelectedItems = lastNameFilterMenu.getSelectedItems();
+				menuSelectedItems = lastNameFilterMenu.getSelectedMenuItems();
 				if (menuSelectedItems != null && !menuSelectedItems.isEmpty()) {
 					selectedItems.addAll(menuSelectedItems);
 				}
 			}
 			if (dobFilterMenu.isVisible()) {
-				menuSelectedItems = dobFilterMenu.getSelectedItems();
+				menuSelectedItems = dobFilterMenu.getSelectedMenuItems();
 				if (menuSelectedItems != null && !menuSelectedItems.isEmpty()) {
 					selectedItems.addAll(menuSelectedItems);
 				}

--- a/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuSelectModeExample.java
+++ b/wcomponents-examples/src/main/java/com/github/bordertech/wcomponents/examples/theme/WMenuSelectModeExample.java
@@ -3,6 +3,7 @@ package com.github.bordertech.wcomponents.examples.theme;
 import com.github.bordertech.wcomponents.Action;
 import com.github.bordertech.wcomponents.ActionEvent;
 import com.github.bordertech.wcomponents.HeadingLevel;
+import com.github.bordertech.wcomponents.MenuItemSelectable;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.WAjaxControl;
 import com.github.bordertech.wcomponents.WButton;
@@ -25,6 +26,7 @@ import com.github.bordertech.wcomponents.WTabSet;
 import com.github.bordertech.wcomponents.WTabSet.TabMode;
 import com.github.bordertech.wcomponents.WText;
 import com.github.bordertech.wcomponents.subordinate.builder.SubordinateBuilder;
+
 import java.util.List;
 
 /**
@@ -333,9 +335,9 @@ public class WMenuSelectModeExample extends WContainer {
 		 * Handle selected text.
 		 */
 		private void handleSelectedText() {
-			List<WComponent> list = menu.getSelectedItems();
+			List<MenuItemSelectable> list = menu.getSelectedMenuItems();
 			StringBuffer selected = new StringBuffer();
-			for (WComponent comp : list) {
+			for (MenuItemSelectable comp : list) {
 				if (comp instanceof WMenuItem) {
 					WMenuItem item = (WMenuItem) comp;
 					selected.append(item.getText()).append(", ");


### PR DESCRIPTION
The methods ```WMenu::getSelectedItem```, ```WMenu::getSelectedItems``` and ```WMenu::clearSelectedItems``` have long been deprecated, so replacing their usage with ```WMenu::getSelectedMenuItem```, ```WMenu::getSelectedMenuItems``` and ```WMenu::clearSelectedMenuItems``` discourages their use.