### PR TITLE
Port redirect off of XML/XSLT

### DIFF
--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
@@ -175,7 +175,7 @@ public class WrongStepAjaxInterceptor extends InterceptorComponent {
 		writer.print("<ui:ajaxtarget id=\"" + triggerId + "\" action=\"replace\">");
 
 		// Redirect URL
-		writer.print(String.format("<%s url=\"%s\"></%s>", TAG_REDIRECT, redirectUrl, TAG_REDIRECT));
+		writer.print(String.format("<%1$s url=\"%2$s\"></%1$s>", TAG_REDIRECT, redirectUrl));
 
 		writer.print("</ui:ajaxtarget>");
 		writer.print("</ui:ajaxresponse>");

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
@@ -175,7 +175,7 @@ public class WrongStepAjaxInterceptor extends InterceptorComponent {
 		writer.print("<ui:ajaxtarget id=\"" + triggerId + "\" action=\"replace\">");
 
 		// Redirect URL
-		writer.print(String.format("<%1$s url=\"%2$s\"></%1$s>", TAG_REDIRECT, redirectUrl));
+		writer.print(String.format("<%s url=\"%s\"></%1$s>", TAG_REDIRECT, redirectUrl));
 
 		writer.print("</ui:ajaxtarget>");
 		writer.print("</ui:ajaxresponse>");

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
@@ -35,6 +35,10 @@ import org.apache.commons.logging.LogFactory;
  * @author Jonathan Austin
  */
 public class WrongStepAjaxInterceptor extends InterceptorComponent {
+
+	/**
+	 * Tag/name for redirect HTML elements.
+	 */
 	public static final String TAG_REDIRECT = "wc-redirect";
 
 	/**

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java
@@ -35,6 +35,7 @@ import org.apache.commons.logging.LogFactory;
  * @author Jonathan Austin
  */
 public class WrongStepAjaxInterceptor extends InterceptorComponent {
+	public static final String TAG_REDIRECT = "wc-redirect";
 
 	/**
 	 * The logger instance for this class.
@@ -170,7 +171,7 @@ public class WrongStepAjaxInterceptor extends InterceptorComponent {
 		writer.print("<ui:ajaxtarget id=\"" + triggerId + "\" action=\"replace\">");
 
 		// Redirect URL
-		writer.print("<ui:redirect url=\"" + redirectUrl + "\" />");
+		writer.print(String.format("<%s url=\"%s\"></%s>", TAG_REDIRECT, redirectUrl, TAG_REDIRECT));
 
 		writer.print("</ui:ajaxtarget>");
 		writer.print("</ui:ajaxresponse>");

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java
@@ -58,10 +58,10 @@ final class WContentRenderer extends AbstractWebXmlRenderer {
 		switch (content.getDisplayMode()) {
 			case DISPLAY_INLINE:
 			case PROMPT_TO_SAVE:
-				xml.appendTagOpen("ui:redirect");
+				xml.appendTagOpen(TAG_REDIRECT);
 				xml.appendUrlAttribute("url", content.getUrl());
 				xml.appendClose();
-				xml.appendEndTag("ui:redirect");
+				xml.appendEndTag(TAG_REDIRECT);
 				break;
 
 			case OPEN_NEW_WINDOW:

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java
@@ -15,6 +15,7 @@ import org.apache.commons.logging.LogFactory;
  * @since 1.0.0
  */
 final class WContentRenderer extends AbstractWebXmlRenderer {
+	public static final String TAG_REDIRECT = "wc-redirect";
 
 	/**
 	 * The logger instance for this class.
@@ -59,7 +60,8 @@ final class WContentRenderer extends AbstractWebXmlRenderer {
 			case PROMPT_TO_SAVE:
 				xml.appendTagOpen("ui:redirect");
 				xml.appendUrlAttribute("url", content.getUrl());
-				xml.appendEnd();
+				xml.appendClose();
+				xml.appendEndTag("ui:redirect");
 				break;
 
 			case OPEN_NEW_WINDOW:

--- a/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java
+++ b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java
@@ -15,6 +15,10 @@ import org.apache.commons.logging.LogFactory;
  * @since 1.0.0
  */
 final class WContentRenderer extends AbstractWebXmlRenderer {
+
+	/**
+	 * Tag/name for redirect HTML elements.
+	 */
 	public static final String TAG_REDIRECT = "wc-redirect";
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor_Test.java
@@ -55,7 +55,9 @@ public class WrongStepAjaxInterceptor_Test extends AbstractWebXmlRendererTestCas
 		app.setLocked(true);
 
 		MockResponse response = doAjaxRequest(app, 1, 99);
-		assertXpathEvaluatesTo("http://test.test", "//ui:redirect/@url", response.getWriterOutput());
+		assertXpathEvaluatesTo("http://test.test",
+								String.format("//%s/@url", WrongStepAjaxInterceptor.TAG_REDIRECT),
+								response.getWriterOutput());
 	}
 
 	@Test
@@ -67,7 +69,9 @@ public class WrongStepAjaxInterceptor_Test extends AbstractWebXmlRendererTestCas
 
 		// Should redirect to app postpath
 		MockResponse response = doAjaxRequest(app, 1, 99);
-		assertXpathEvaluatesTo(APP_POSTPATH, "//ui:redirect/@url", response.getWriterOutput());
+		assertXpathEvaluatesTo(APP_POSTPATH,
+								String.format("//%s/@url", WrongStepAjaxInterceptor.TAG_REDIRECT),
+								response.getWriterOutput());
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer_Test.java
@@ -51,7 +51,7 @@ public class WContentRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathUrlEvaluatesTo(wContent.getUrl(), "//ui:popup/@url", wContent);
 		// Display again (as reset after paint)
 		wContent.display();
-		assertXpathNotExists("ui:redirect", wContent);
+		assertXpathNotExists(WContentRenderer.TAG_REDIRECT, wContent);
 
 		// Test all options
 		String width = "111";
@@ -69,7 +69,10 @@ public class WContentRenderer_Test extends AbstractWebXmlRendererTestCase {
 
 		// Display again (as reset after paint)
 		wContent.display();
-		assertXpathUrlEvaluatesTo(wContent.getUrl(), "//ui:redirect/@url", wContent);
+		assertXpathUrlEvaluatesTo(wContent.getUrl(),
+									String.format("//%s/@url", WContentRenderer.TAG_REDIRECT),
+									wContent);
+//		assertXpathUrlEvaluatesTo(wContent.getUrl(), "//wc-redirect/@url", wContent);
 
 		// Test null content
 		wContent.setContentAccess(null);

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer_Test.java
@@ -51,7 +51,7 @@ public class WContentRenderer_Test extends AbstractWebXmlRendererTestCase {
 		assertXpathUrlEvaluatesTo(wContent.getUrl(), "//ui:popup/@url", wContent);
 		// Display again (as reset after paint)
 		wContent.display();
-		assertXpathNotExists(WContentRenderer.TAG_REDIRECT, wContent);
+		assertXpathNotExists(String.format("//html:%s", WContentRenderer.TAG_REDIRECT), wContent);
 
 		// Test all options
 		String width = "111";
@@ -70,9 +70,8 @@ public class WContentRenderer_Test extends AbstractWebXmlRendererTestCase {
 		// Display again (as reset after paint)
 		wContent.display();
 		assertXpathUrlEvaluatesTo(wContent.getUrl(),
-									String.format("//%s/@url", WContentRenderer.TAG_REDIRECT),
+									String.format("//html:%s/@url", WContentRenderer.TAG_REDIRECT),
 									wContent);
-//		assertXpathUrlEvaluatesTo(wContent.getUrl(), "//wc-redirect/@url", wContent);
 
 		// Test null content
 		wContent.setContentAccess(null);

--- a/wcomponents-theme/src/main/js/wc/ui/redirect.mjs
+++ b/wcomponents-theme/src/main/js/wc/ui/redirect.mjs
@@ -21,7 +21,6 @@ const doRedirect = debounce(/**
 	 * @param {string} url The url to redirect to.
 	 */
 	function(url) {
-
 		if (instance.isLaunchUrl(url)) {
 			const target = getRedirectFrame();
 			target.src = url;
@@ -106,6 +105,17 @@ function getRedirectFrame() {
 		document.body.appendChild(result);
 	}
 	return result;
+}
+
+const redirectTag = "wc-redirect";
+class WRedirect extends HTMLElement {
+	connectedCallback() {
+		instance.register(this.getAttribute("url"));
+	}
+}
+
+if (!customElements.get(redirectTag)) {
+	customElements.define(redirectTag, WRedirect);
 }
 
 export default instance;

--- a/wcomponents-theme/src/main/js/wc/ui/redirect.mjs
+++ b/wcomponents-theme/src/main/js/wc/ui/redirect.mjs
@@ -21,6 +21,7 @@ const doRedirect = debounce(/**
 	 * @param {string} url The url to redirect to.
 	 */
 	function(url) {
+
 		if (instance.isLaunchUrl(url)) {
 			const target = getRedirectFrame();
 			target.src = url;
@@ -29,7 +30,7 @@ const doRedirect = debounce(/**
 			MDC: https://developer.mozilla.org/en/window.parent
 			If a window does not have a parent, its parent property is a reference to itself.
 			*/
-			window.parent.location.href = url;
+			window.parent.location.replace(url);
 		}
 	}, 50);
 

--- a/wcomponents-theme/src/test/spec/wc.ui.redirect.test.mjs
+++ b/wcomponents-theme/src/test/spec/wc.ui.redirect.test.mjs
@@ -1,20 +1,16 @@
 import redirect from "wc/ui/redirect.mjs";
 
 describe("wc/ui/redirect", () => {
-	// window = Object.create(Window);
-
-	const delay = 50;  // milliseconds to wait for events and stuff to be actioned
 	const origWindow = window.parent;
-	const replaceSpy = jasmine.createSpy();
 
 	beforeEach(() => {
+		let storedUrl = "";
 		window.parent = {
-			location : {
-				storedUrl : "",
+			location: {
 				set href(url) {
-					this.storedUrl = url;
+					storedUrl = url;
 				},
-				replace : function (url) {
+				replace: function (url) {
 					this.href = url;
 				}
 			}
@@ -24,37 +20,27 @@ describe("wc/ui/redirect", () => {
 	it("does nothing with an empty url", () => {
 		spyOnProperty(window.parent.location, "href", "set")
 			.and.throwError("href should not be getting touched for empty url");
-		spyOn(redirect, "register").and.callThrough();
 		redirect.register("");
-		expect(redirect.register).toHaveBeenCalledTimes(1);
 	});
 
 	it("redirects to the given non-launch url", () => {
-		spyOn(redirect, "register").and.callThrough();
 		return testRegister("https://github.com/BorderTech/wcomponents", false);
 	});
 
 	it("does not redirect to new url given a launch url", () => {
-		spyOn(redirect, "register").and.callThrough();
 		return testRegister("mailto:test@email.com", true);
 	});
 
 	it("recognises attachment links as launch links", () => {
-		spyOn(redirect, "isLaunchUrl").and.callThrough();
 		expect(redirect.isLaunchUrl("mailto:test@email.com")).toBeTrue();
-		expect(redirect.isLaunchUrl).toHaveBeenCalledTimes(1);
 	});
 
-	it("recognises pseudoprotocol links as launch links", () => {
-		spyOn(redirect, "isLaunchUrl").and.callThrough();
+	it("recognises pseudo-protocol links as launch links", () => {
 		expect(redirect.isLaunchUrl("https://example.com/wc_content=attach")).toBeTrue();
-		expect(redirect.isLaunchUrl).toHaveBeenCalledTimes(1);
 	});
 
 	it("does not recognise regular navigation links as launch links", () => {
-		spyOn(redirect, "isLaunchUrl").and.callThrough();
 		expect(redirect.isLaunchUrl("https://example.com")).toBeFalse();
-		expect(redirect.isLaunchUrl).toHaveBeenCalledTimes(1);
 	});
 
 	// used for async "register" tests, i.e. anything where url isn't blank
@@ -63,12 +49,10 @@ describe("wc/ui/redirect", () => {
 			spyOnProperty(window.parent.location, "href", "set").and.callFake((url) => {
 				expect(url).toBe(inputUrl);
 				expect(isLaunchUrl).toBeFalse();
-				expect(redirect.register).toHaveBeenCalledTimes(1);
 				resolve();
 			});
 			spyOn(document, "getElementById").and.callFake(() => {
 				expect(isLaunchUrl).toBeTrue();
-				expect(redirect.register).toHaveBeenCalledTimes(1);
 				resolve();
 			});
 			redirect.register(inputUrl);

--- a/wcomponents-theme/src/test/spec/wc.ui.redirect.test.mjs
+++ b/wcomponents-theme/src/test/spec/wc.ui.redirect.test.mjs
@@ -1,0 +1,81 @@
+import redirect from "wc/ui/redirect.mjs";
+
+describe("wc/ui/redirect", () => {
+	// window = Object.create(Window);
+
+	const delay = 50;  // milliseconds to wait for events and stuff to be actioned
+	const origWindow = window.parent;
+	const replaceSpy = jasmine.createSpy();
+
+	beforeEach(() => {
+		window.parent = {
+			location : {
+				storedUrl : "",
+				set href(url) {
+					this.storedUrl = url;
+				},
+				replace : function (url) {
+					this.href = url;
+				}
+			}
+		};
+	});
+
+	it("does nothing with an empty url", () => {
+		spyOnProperty(window.parent.location, "href", "set")
+			.and.throwError("href should not be getting touched for empty url");
+		spyOn(redirect, "register").and.callThrough();
+		redirect.register("");
+		expect(redirect.register).toHaveBeenCalledTimes(1);
+	});
+
+	it("redirects to the given non-launch url", () => {
+		spyOn(redirect, "register").and.callThrough();
+		return testRegister("https://github.com/BorderTech/wcomponents", false);
+	});
+
+	it("does not redirect to new url given a launch url", () => {
+		spyOn(redirect, "register").and.callThrough();
+		return testRegister("mailto:test@email.com", true);
+	});
+
+	it("recognises attachment links as launch links", () => {
+		spyOn(redirect, "isLaunchUrl").and.callThrough();
+		expect(redirect.isLaunchUrl("mailto:test@email.com")).toBeTrue();
+		expect(redirect.isLaunchUrl).toHaveBeenCalledTimes(1);
+	});
+
+	it("recognises pseudoprotocol links as launch links", () => {
+		spyOn(redirect, "isLaunchUrl").and.callThrough();
+		expect(redirect.isLaunchUrl("https://example.com/wc_content=attach")).toBeTrue();
+		expect(redirect.isLaunchUrl).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not recognise regular navigation links as launch links", () => {
+		spyOn(redirect, "isLaunchUrl").and.callThrough();
+		expect(redirect.isLaunchUrl("https://example.com")).toBeFalse();
+		expect(redirect.isLaunchUrl).toHaveBeenCalledTimes(1);
+	});
+
+	// used for async "register" tests, i.e. anything where url isn't blank
+	function testRegister (inputUrl, isLaunchUrl) {
+		return new Promise((resolve) => {
+			spyOnProperty(window.parent.location, "href", "set").and.callFake((url) => {
+				expect(url).toBe(inputUrl);
+				expect(isLaunchUrl).toBeFalse();
+				expect(redirect.register).toHaveBeenCalledTimes(1);
+				resolve();
+			});
+			spyOn(document, "getElementById").and.callFake(() => {
+				expect(isLaunchUrl).toBeTrue();
+				expect(redirect.register).toHaveBeenCalledTimes(1);
+				resolve();
+			});
+			redirect.register(inputUrl);
+		});
+	}
+
+	afterAll(() => {
+		window.parent = origWindow;
+	});
+});

--- a/wcomponents-xslt/src/main/xslt/all.xsl
+++ b/wcomponents-xslt/src/main/xslt/all.xsl
@@ -340,7 +340,6 @@
 		<xsl:variable name="multiDDData"
 			select=".//ui:multidropdown[@data and not(@readOnly)]" />
 		<xsl:variable name="popups" select=".//ui:popup" />
-		<xsl:variable name="redirects" select=".//ui:redirect" />
 		<xsl:variable name="rtfs" select=".//ui:textarea[ui:rtf]" />
 		<xsl:variable name="eagerness" select="//*[@mode eq 'eager']" />
 		<xsl:variable name="editors" select=".//html:wc-imageedit" />
@@ -545,11 +544,6 @@
 				<xsl:text>import("wc/ui/popup.mjs").then(({ default: c }) => {c.register([</xsl:text>
 				<xsl:apply-templates select="$popups" mode="JS" />
 				<xsl:text>])});</xsl:text>
-			</xsl:if>
-			<xsl:if test="$redirects">
-				<xsl:text>import("wc/ui/redirect.mjs").then(({ default: c }) => {c.register(</xsl:text>
-				<xsl:apply-templates select="$redirects[1]" mode="JS" />
-				<xsl:text>);});</xsl:text>
 			</xsl:if>
 			<xsl:if test="$rtfs">
 				<xsl:text>import("wc/ui/rtf.mjs").then(({ default: c }) => {c.register([</xsl:text>


### PR DESCRIPTION
Removes client-side redirects off of the XSLT registration scripts. Uses HTML custom elements, like #1837.

Currently it seems to be functionally correct but the code does define the redirect tag in two different spots ([one in WrongStepAjaxInterceptor](https://github.com/BorderTech/wcomponents/blob/c682a6cf75f9840adcc2eeb9e85824a20874524b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/container/WrongStepAjaxInterceptor.java#L39C1-L42) and [one in ContentRenderer](https://github.com/BorderTech/wcomponents/blob/c682a6cf75f9840adcc2eeb9e85824a20874524b/wcomponents-core/src/main/java/com/github/bordertech/wcomponents/render/webxml/WContentRenderer.java#L19-L22)). This likely ought to be in one spot but I wasn't sure which one spot.