### PR TITLE
Fix calendar not closing when it loses focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log
 
 ## Release in-progress
+* Fix calendar not closing in webkit browsers when it loses focus to a non-focusable element.
 
 ### API Changes
 ### Enhancements


### PR DESCRIPTION
Certain older browsers used to fire a focus event event when the body gained focus. Many modern browsers do not do this, which means the calendar will not reliably close when it loses focus.