### PR TITLE
Fix and update project dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### API Changes
 ### Enhancements
 * Update project dependencies to current versions
+* Fix convergent dependencies by using excludes and adding the required dependency directly. Only using
+  DependencyManagement in the parent pom is not reliable for library projects.
+
 ### Bug Fixes
 * The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles
   the reduced pom files. The reduced pom removes all the dependencies which impacts the use of the main attached jar so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### API Changes
 ### Enhancements
+* Update project dependencies to current versions
 ### Bug Fixes
 * The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles
   the reduced pom files. The reduced pom removes all the dependencies which impacts the use of the main attached jar so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### API Changes
 ### Enhancements
 ### Bug Fixes
+* The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles
+  the reduced pom files. The reduced pom removes all the dependencies which impacts the use of the main attached jar so
+  its creation has been disabled.
 
 ## 1.5.35
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles
   the reduced pom files. The reduced pom removes all the dependencies which impacts the use of the main attached jar so
   its creation has been disabled.
+* Improve performance unit test messaging and increase padding factors to help avoid intermittent fails.
 
 ## 1.5.35
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update project dependencies to current versions
 * Fix convergent dependencies by using excludes and adding the required dependency directly. Only using
   DependencyManagement in the parent pom is not reliable for library projects.
+* Update velocity from 2.3 to 2.4. Refer to changelog below for 1.5.35 on backward compatability to version 1.5 and 1.7.
 
 ### Bug Fixes
 * The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 * Fix convergent dependencies by using excludes and adding the required dependency directly. Only using
   DependencyManagement in the parent pom is not reliable for library projects.
 * Update velocity from 2.3 to 2.4. Refer to changelog below for 1.5.35 on backward compatability to version 1.5 and 1.7.
+* Use jcl-over-slf4j from SLF4J to provide the commons-logging API.
+  * Libraries used by WComponents use SLF4J and WComponents currently uses common-loggings which routes to SLF4J. SLF4J
+  recommend using their jcl-over-slf4j dependency to direct any libraries using commons-logging to SLF4J to avoid
+  classpath issues (Refer to https://www.slf4j.org/legacy.html#jclOverSLF4J).
+  * Exclude commons-logging from transitive dependencies to make sure jcl-over-slf4j is used instead to direct JCL to SLF4J.
+  * jcl-over-slf4j can be used until WComponents is refactored to use SLF4J.
 
 ### Bug Fixes
 * The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.16.1</version>
+				<version>2.17.0</version>
 			</dependency>
 			<dependency>
 				<groupId>commons-lang</groupId>
@@ -168,27 +168,27 @@
 			<dependency>
 				<groupId>org.apache.httpcomponents.client5</groupId>
 				<artifactId>httpclient5</artifactId>
-				<version>5.3.1</version>
+				<version>5.4</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents.core5</groupId>
 				<artifactId>httpcore5</artifactId>
-				<version>5.2.5</version>
+				<version>5.3</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.httpcomponents.core5</groupId>
 				<artifactId>httpcore5-h2</artifactId>
-				<version>5.2.5</version>
+				<version>5.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>33.3.0-jre</version>
+				<version>33.3.1-jre</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.errorprone</groupId>
 				<artifactId>error_prone_annotations</artifactId>
-				<version>2.31.0</version>
+				<version>2.32.0</version>
 			</dependency>
 			
 			<!-- Required for HTML input sanitization of WTextArea -->

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
 
 	<dependencyManagement>
 		<dependencies>
+
+			<!-- Junit -->
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
@@ -79,6 +81,15 @@
 						<groupId>org.glassfish.jaxb</groupId>
 						<artifactId>jaxb-runtime</artifactId>
 					</exclusion>
+					<!-- Fix convergence -->
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>javax.cache</groupId>
+						<artifactId>cache-api</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<!-- Specific JAXB runtime for cache provider -->
@@ -87,7 +98,8 @@
 				<artifactId>jaxb-runtime</artifactId>
 				<version>4.0.5</version>
 			</dependency>
-			<!-- Libraries used by WComponents use SLF4J. WComponents uses common loggings. You will need to include
+
+			<!-- Libraries used by WComponents use SLF4J. WComponents uses common loggings which routes to SLF4J. You will need to include
 			the appropiate SLF4J library for your logging framework. -->
 			<dependency>
 				<groupId>org.slf4j</groupId>
@@ -100,111 +112,12 @@
 				<version>2.0.16</version>
 			</dependency>
 
-			<!-- Force versions to help avoid convergence errors -->
-			<dependency>
-				<groupId>commons-logging</groupId>
-				<artifactId>commons-logging</artifactId>
-				<!-- As of 1.3.X commons logging detects and routes logging to SLF4J if in the classpath -->
-				<version>1.3.4</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-collections</groupId>
-				<artifactId>commons-collections</artifactId>
-				<version>3.2.2</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-io</groupId>
-				<artifactId>commons-io</artifactId>
-				<version>2.17.0</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-lang</groupId>
-				<artifactId>commons-lang</artifactId>
-				<version>2.6</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-lang3</artifactId>
-				<version>3.17.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-compress</artifactId>
-				<version>1.27.1</version>
-			</dependency>
-			<dependency>
-				<groupId>commons-codec</groupId>
-				<artifactId>commons-codec</artifactId>
-				<version>1.17.1</version>
-			</dependency>
-			<dependency>
-				<groupId>xml-apis</groupId>
-				<artifactId>xml-apis</artifactId>
-				<version>1.4.01</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.xmlgraphics</groupId>
-				<artifactId>batik-css</artifactId>
-				<version>1.17</version>
-			</dependency>
-			<dependency>
-				<groupId>xerces</groupId>
-				<artifactId>xercesImpl</artifactId>
-				<version>2.12.2</version>
-			</dependency>
-			<!-- Caching API. -->
-			<dependency>
-				<groupId>javax.cache</groupId>
-				<artifactId>cache-api</artifactId>
-				<version>1.1.1</version>
-			</dependency>
 			<!-- Servlet Interface -->
 			<dependency>
 				<groupId>javax.servlet</groupId>
 				<artifactId>servlet-api</artifactId>
 				<version>2.5</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.httpcomponents.client5</groupId>
-				<artifactId>httpclient5</artifactId>
-				<version>5.4</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents.core5</groupId>
-				<artifactId>httpcore5</artifactId>
-				<version>5.3</version>
-			</dependency>
-			<dependency>
-				<groupId>org.apache.httpcomponents.core5</groupId>
-				<artifactId>httpcore5-h2</artifactId>
-				<version>5.3</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.guava</groupId>
-				<artifactId>guava</artifactId>
-				<version>33.3.1-jre</version>
-			</dependency>
-			<dependency>
-				<groupId>com.google.errorprone</groupId>
-				<artifactId>error_prone_annotations</artifactId>
-				<version>2.32.0</version>
-			</dependency>
-			
-			<!-- Required for HTML input sanitization of WTextArea -->
-			<!-- Antisamy as of 1.7.X does not support xhtml and will remove the closing tag on "void" elements which will break the XML-->
-			<!-- Once WComponents stops using xslt then the latest Antisamy can be used -->
-			<!-- https://html.spec.whatwg.org/multipage/syntax.html#void-elements -->
-			<dependency>
-				<groupId>org.owasp.antisamy</groupId>
-				<artifactId>antisamy</artifactId>
-				<version>1.6.8</version>
-			</dependency>
-			<!-- Neko-htmlunit had a package rename as of 3.X.X and cannot be picked up until latest Antisamy can be used -->
-			<dependency>
-				<groupId>net.sourceforge.htmlunit</groupId>
-				<artifactId>neko-htmlunit</artifactId>
-				<version>2.70.0</version>
+				<scope>provided</scope>
 			</dependency>
 
 		</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 
 	<properties>
 		<jetty.version>8.1.16.v20140903</jetty.version>
+		<slf4j.version>2.0.16</slf4j.version>
 		<bt.qa.skip>false</bt.qa.skip>
 		<bt.convergence.check.fail>true</bt.convergence.check.fail>
 		<!-- Report Vulnerabilities. -->
@@ -97,19 +98,6 @@
 				<groupId>org.glassfish.jaxb</groupId>
 				<artifactId>jaxb-runtime</artifactId>
 				<version>4.0.5</version>
-			</dependency>
-
-			<!-- Libraries used by WComponents use SLF4J. WComponents uses common loggings which routes to SLF4J. You will need to include
-			the appropiate SLF4J library for your logging framework. -->
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-api</artifactId>
-				<version>2.0.16</version>
-			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-simple</artifactId>
-				<version>2.0.16</version>
 			</dependency>
 
 			<!-- Servlet Interface -->

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -44,11 +44,11 @@
 			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
 
-		<!-- Libraries used by WComponents use SLF4J. WComponents uses common loggings. You will need to include
-		the appropiate SLF4J library for your logging framework. -->
+		<!-- SLF4J implementation. -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -119,8 +119,8 @@
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 			<version>1.10</version>
-			<!-- Fix convergence -->
 			<exclusions>
+				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
@@ -132,8 +132,8 @@
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
 			<version>1.9.4</version>
-			<!-- Fix convergence -->
 			<exclusions>
+				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
@@ -269,12 +269,13 @@
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-css</artifactId>
 			<version>1.17</version>
-			<!-- Fix convergence -->
 			<exclusions>
+				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
+				<!-- Fix convergence -->
 				<exclusion>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
@@ -319,21 +320,26 @@
 			</exclusions>
 		</dependency>
 
-		<!-- Force versions to fix convergence -->
+		<!-- Libraries used by WComponents use SLF4J and WComponents currently uses common-loggings which routes to SLF4J.
+		SLF4J recommend using their jcl-over-slf4j dependency to direct any libraries using commons-logging to SLF4J
+		to avoid classpath issues (Refer to https://www.slf4j.org/legacy.html#jclOverSLF4J).
+		This can be used until WComponents is refactored to use SLF4J. -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>jcl-over-slf4j</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
 		</dependency>
+
+		<!-- Force versions to fix convergence -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>3.17.0</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<!-- As of 1.3.X commons logging detects and routes logging to SLF4J if in the classpath -->
-			<version>1.3.4</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -379,10 +385,11 @@
 			<version>1.8</version>
 			<scope>test</scope>
 		</dependency>
-		<!-- commons-logging as of 1.3.X detects SLF4J and the performance unit tests fail when SLF4J doeesnot have a backing provider -->
+		<!-- Performance unit tests fail when SLF4J doesnot have a backing provider -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<!-- JSR107 Caching provider. -->

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -109,28 +109,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<!-- Include from Dependenecy Management to help avoid convergence errors -->
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-collections</groupId>
-			<artifactId>commons-collections</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>xml-apis</groupId>
-			<artifactId>xml-apis</artifactId>
-		</dependency>
-		<!-- Servlet Interface -->
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
@@ -138,46 +116,42 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-		</dependency>
-
-		<dependency>
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 			<version>1.10</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
 			<version>1.9.4</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
-
 
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
 			<version>1.5</version>
-		</dependency>
-
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
-
-		<dependency>
-			<scope>test</scope>
-			<groupId>xmlunit</groupId>
-			<artifactId>xmlunit</artifactId>
-			<version>1.6</version>
-		</dependency>
-
-		<dependency>
-			<scope>test</scope>
-			<groupId>junitperf</groupId>
-			<artifactId>junitperf</artifactId>
-			<version>1.8</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -203,6 +177,13 @@
 			<artifactId>handlebars</artifactId>
 			<!-- Above 4.4.X requires java 17 -->
 			<version>4.3.1</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Velocity template support. -->
@@ -210,50 +191,102 @@
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity-engine-core</artifactId>
 			<version>2.3</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Caching API. -->
 		<dependency>
 			<groupId>javax.cache</groupId>
 			<artifactId>cache-api</artifactId>
-		</dependency>
-
-		<!-- JSR107 Caching provider. -->
-		<dependency>
-			<scope>test</scope>
-			<groupId>org.ehcache</groupId>
-			<artifactId>ehcache</artifactId>
-		</dependency>
-		<!-- JAXB runtime for cache provider -->
-		<dependency>
-			<scope>test</scope>
-			<groupId>org.glassfish.jaxb</groupId>
-			<artifactId>jaxb-runtime</artifactId>
+			<version>1.1.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.11.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
+		<!-- Required for HTML input sanitization of WTextArea -->
+		<!-- Antisamy as of 1.7.X does not support xhtml and will remove the closing tag on "void" elements which will break the XML-->
+		<!-- Once WComponents stops using xslt then the latest Antisamy can be used -->
+		<!-- https://html.spec.whatwg.org/multipage/syntax.html#void-elements -->
 		<dependency>
 			<groupId>org.owasp.antisamy</groupId>
 			<artifactId>antisamy</artifactId>
+			<version>1.6.8</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.xmlgraphics</groupId>
+					<artifactId>batik-css</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents.client5</groupId>
+					<artifactId>httpclient5</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents.core5</groupId>
+					<artifactId>httpcore5</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.sourceforge.htmlunit</groupId>
+					<artifactId>neko-htmlunit</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- Neko-htmlunit had a package rename as of 3.X.X and cannot be picked up until latest Antisamy can be used -->
+		<dependency>
+			<groupId>net.sourceforge.htmlunit</groupId>
+			<artifactId>neko-htmlunit</artifactId>
+			<version>2.70.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-css</artifactId>
+			<version>1.17</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+			</exclusions>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
+			<version>2.12.2</version>
 			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>net.sourceforge.htmlunit</groupId>
-			<artifactId>neko-htmlunit</artifactId>
 		</dependency>
 
 		<!-- Device detection -->
@@ -273,12 +306,95 @@
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
 			<version>2.9.2</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
+		<!-- Force versions to fix convergence -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.17.0</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<!-- As of 1.3.X commons logging detects and routes logging to SLF4J if in the classpath -->
+			<version>1.3.4</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.17.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.errorprone</groupId>
+			<artifactId>error_prone_annotations</artifactId>
+			<version>2.33.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.client5</groupId>
+			<artifactId>httpclient5</artifactId>
+			<version>5.4</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents.core5</groupId>
+			<artifactId>httpcore5</artifactId>
+			<version>5.3</version>
+		</dependency>
+
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>xmlunit</groupId>
+			<artifactId>xmlunit</artifactId>
+			<version>1.6</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>junitperf</groupId>
+			<artifactId>junitperf</artifactId>
+			<version>1.8</version>
+			<scope>test</scope>
+		</dependency>
 		<!-- commons-logging as of 1.3.X detects SLF4J and the performance unit tests fail when SLF4J doeesnot have a backing provider -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- JSR107 Caching provider. -->
+		<dependency>
+			<groupId>org.ehcache</groupId>
+			<artifactId>ehcache</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- JAXB runtime for cache provider -->
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
 			<scope>test</scope>
 		</dependency>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -190,7 +190,7 @@
 		<dependency>
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity-engine-core</artifactId>
-			<version>2.3</version>
+			<version>2.4</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>

--- a/wcomponents-core/src/main/resources/com/github/bordertech/wcomponents/web.properties
+++ b/wcomponents-core/src/main/resources/com/github/bordertech/wcomponents/web.properties
@@ -1,8 +1,8 @@
 # Settings for the web framework
 
-# The server-relative path to the theme in use. This is only necessary 
+# The server-relative path to the theme in use. This is only necessary
 # when deploying themes in a web-app separate to those provided by WComponents.
-# 
+#
 # e.g.
 #   bordertech.wcomponents.theme.content.path=/themes/html/${bordertech.wcomponents.theme.name}
 # e.g. if using the deprecated themeServlet
@@ -117,7 +117,7 @@ bordertech.wcomponents.velocity.cache.enabled   = true
 bordertech.wcomponents.velocity.backward17.enabled=true
 
 ## Velocity 1.7 properties
-# Refer to https://velocity.apache.org/engine/2.3/upgrading.html
+# Refer to https://velocity.apache.org/engine/2.4/upgrading.html
 # No automatic conversion of methods arguments
 bt.velocity.backward17.introspector.conversion_handler.class = none
 # Use backward compatible space gobbling
@@ -134,3 +134,5 @@ bt.velocity.backward17.event_handler.invalid_references.quiet = true
 bt.velocity.backward17.event_handler.invalid_references.null = true
 # When using an invalid reference handler, also include tested references (since 2.2)
 bt.velocity.backward17.event_handler.invalid_references.tested = true
+# Let the range operator expressions '[ x..y ]' return mutable lists (since 2.4)
+bt.velocity.backward17.runtime.immutable_ranges = false

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/SerializationPerformance_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/SerializationPerformance_Test.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -32,12 +31,6 @@ import org.junit.experimental.categories.Category;
  */
 @Category(PerformanceTests.class)
 public class SerializationPerformance_Test extends AbstractWComponentTestCase {
-
-	/**
-	 * The number of repetitions to use for testing serialization time. This should be set to be greater than the
-	 * minimum number of invocations required to trigger JIT compilation.
-	 */
-	private static final int NUM_REPETITIONS = 2000;
 
 	/**
 	 * The logger instance for this class.
@@ -59,8 +52,7 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 
 		LOG.info("Optimised size - clean session: " + registeredSize);
 		LOG.info("default size - clean session: " + nonRegisteredSize);
-		assertLessThan("Optimised size should be smaller than default", registeredSize,
-				nonRegisteredSize);
+		assertLessThan("Optimised size should be smaller than default", registeredSize, nonRegisteredSize);
 
 		// Test used session - 50% components with models
 		createUserModels(nonRegistered, nonRegisteredContext, 50);
@@ -71,8 +63,7 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 
 		LOG.info("Optimised size - 50% models: " + registeredSize);
 		LOG.info("default size - 50% models: " + nonRegisteredSize);
-		assertLessThan("Optimised size should be smaller than default", registeredSize,
-				nonRegisteredSize);
+		assertLessThan("Optimised size should be smaller than default", registeredSize, nonRegisteredSize);
 
 		// Test used session - 100% components with models
 		createUserModels(nonRegistered, nonRegisteredContext, 100);
@@ -83,8 +74,7 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 
 		LOG.info("Optimised size - 100% models: " + registeredSize);
 		LOG.info("default size - 100% models: " + nonRegisteredSize);
-		assertLessThan("Optimised size should be smaller than default", registeredSize,
-				nonRegisteredSize);
+		assertLessThan("Optimised size should be smaller than default", registeredSize, nonRegisteredSize);
 	}
 
 	@Test
@@ -117,14 +107,12 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 		UIContext registeredContext = createUIContext();
 
 		// Test clean session
-		long nonRegisteredTime = serializeSession(nonRegistered, nonRegisteredContext,
-				NUM_REPETITIONS);
+		long nonRegisteredTime = serializeSession(nonRegistered, nonRegisteredContext, NUM_REPETITIONS);
 		long registeredTime = serializeSession(registered, registeredContext, NUM_REPETITIONS);
 
 		LOG.info("Optimised time - clean session: " + (registeredTime / 1000000.0) + "ms");
 		LOG.info("default time - clean session: " + (nonRegisteredTime / 1000000.0) + "ms");
-		assertLessThan("Optimised time should be less than default time", registeredTime,
-				nonRegisteredTime);
+		assertLessThan("Optimised time should be less than default time", registeredTime, nonRegisteredTime);
 
 		// Test used session - 50% components with models
 		createUserModels(nonRegistered, nonRegisteredContext, 50);
@@ -135,8 +123,7 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 
 		LOG.info("Optimised time - 50% models: " + (registeredTime / 1000000.0) + "ms");
 		LOG.info("default time - 50% models: " + (nonRegisteredTime / 1000000.0) + "ms");
-		assertLessThan("Optimised time should be less than default time", registeredTime,
-				nonRegisteredTime);
+		assertLessThan("Optimised time should be less than default time", registeredTime, nonRegisteredTime);
 
 		// Test used session - 100% components with models
 		createUserModels(nonRegistered, nonRegisteredContext, 100);
@@ -147,8 +134,7 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 
 		LOG.info("Optimised time - 100% models: " + (registeredTime / 1000000.0) + "ms");
 		LOG.info("default time - 100% models: " + (nonRegisteredTime / 1000000.0) + "ms");
-		assertLessThan("Optimised time should be less than default time", registeredTime,
-				nonRegisteredTime);
+		assertLessThan("Optimised time should be less than default time", registeredTime, nonRegisteredTime);
 	}
 
 	@Test
@@ -168,7 +154,9 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 
 		LOG.info("Optimised time - 50% models 1x: " + (registered1Time / 1000000.0) + "ms");
 		LOG.info("Optimised time - 50% models 10x: " + (registered10Time / 1000000.0) + "ms");
-		assertLessThan("Time scaling should be O(n)", registered10Time, registered1Time * 10);
+
+		// Should be a factor of x10 for O(n) but use x12 as a padding factor to avoid intermittent fails
+		assertLessThan("Time scaling should be O(n)", registered10Time, registered1Time * 12);
 	}
 
 	/**
@@ -297,17 +285,6 @@ public class SerializationPerformance_Test extends AbstractWComponentTestCase {
 				findWComponents(((Container) comp).getChildAt(i), result);
 			}
 		}
-	}
-
-	/**
-	 * Asserts that <code>first</code> is less than <code>second</code>.
-	 *
-	 * @param text the assertion text.
-	 * @param first the first parameter to check.
-	 * @param second the second parameter to check.
-	 */
-	private static void assertLessThan(final String text, final long first, final long second) {
-		Assert.assertTrue(text + ": " + first + " < " + second, first < second);
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WComponentsPerformance_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/WComponentsPerformance_Test.java
@@ -70,7 +70,7 @@ public class WComponentsPerformance_Test extends AbstractWComponentTestCase {
 
 	@Test
 	public void testRequestHandlingPerformance() throws Exception {
-		final int numLoops = 2000;
+		final int numLoops = NUM_REPETITIONS;
 
 		long simpleTime = timeOtherServlet(numLoops) / numLoops;
 		long wcomponentTime = timeWComponentProcessing(numLoops) / numLoops;
@@ -78,8 +78,7 @@ public class WComponentsPerformance_Test extends AbstractWComponentTestCase {
 		LOG.info("Simple request handling time: " + (simpleTime / 1000000.0) + "ms");
 		LOG.info("WComponent request handling time: " + (wcomponentTime / 1000000.0) + "ms");
 
-		Assert.assertTrue("WComponent request handling time should not exceed 10x simple time",
-				wcomponentTime < simpleTime * 10);
+		assertLessThan("WComponent request handling time should not exceed 12x simple time", wcomponentTime, simpleTime * 12);
 	}
 
 	/**

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/servlet/WServletPerformance_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/servlet/WServletPerformance_Test.java
@@ -8,9 +8,9 @@ import com.github.bordertech.wcomponents.PerformanceTests;
 import com.github.bordertech.wcomponents.Request;
 import com.github.bordertech.wcomponents.UIContext;
 import com.github.bordertech.wcomponents.WApplication;
-import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WButton;
 import com.github.bordertech.wcomponents.WComponent;
+import com.github.bordertech.wcomponents.WContainer;
 import com.github.bordertech.wcomponents.WLabel;
 import com.github.bordertech.wcomponents.WTextField;
 import com.github.bordertech.wcomponents.WebUtilities;
@@ -102,7 +102,7 @@ public class WServletPerformance_Test extends AbstractWComponentTestCase {
 
 	@Test
 	public void testServletPerformance() throws Exception {
-		final int numLoops = 2000;
+		final int numLoops = NUM_REPETITIONS;
 
 		// Run the test with the simple servlet
 		long simpleTime = timeOtherServlet(numLoops) / numLoops;
@@ -111,8 +111,7 @@ public class WServletPerformance_Test extends AbstractWComponentTestCase {
 		LOG.info("Simple servlet time: " + (simpleTime / 1000000.0) + "ms");
 		LOG.info("WComponent servlet time: " + (wservletTime / 1000000.0) + "ms");
 
-		Assert.assertTrue("WComponent servlet time should not exceed 10x simple time",
-				wservletTime < simpleTime * 10);
+		assertLessThan("WComponent servlet time should not exceed 12x simple time", wservletTime, simpleTime * 12);
 	}
 
 	/**
@@ -399,12 +398,12 @@ public class WServletPerformance_Test extends AbstractWComponentTestCase {
 					"\n<label id=\"label_formBean.property1\" for=\"formBean.property1\">Property 1:</label>");
 			writer.print(
 					"\n<input type=\"text\" id=\"formBean.property1\" name=\"formBean.property1\" value=\"" + BeanUtils.
-					getProperty(formBean, "property1") + "\"/>");
+							getProperty(formBean, "property1") + "\"/>");
 			writer.print(
 					"\n<label id=\"label_formBean.property2\" for=\"formBean.property2\">Property 2:</label>");
 			writer.print(
 					"\n<input type=\"text\" id=\"formBean.property2\" name=\"formBean.property2\" value=\"" + BeanUtils.
-					getProperty(formBean, "property2") + "\"/>");
+							getProperty(formBean, "property2") + "\"/>");
 			writer.print("\n<input type=\"submit\" id=\"submit\" name=\"submit\" value=\"Submit\">");
 			writer.print("\n</form>");
 

--- a/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/util/HTMLSanitizerPerformance_Test.java
+++ b/wcomponents-core/src/test/java/com/github/bordertech/wcomponents/util/HTMLSanitizerPerformance_Test.java
@@ -4,12 +4,12 @@ import com.github.bordertech.wcomponents.AbstractWComponentTestCase;
 import com.github.bordertech.wcomponents.PerformanceTests;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 /**
  * Rudimentary performance test of HTML Sanitizer.
+ *
  * @author Mark Reeves
  * @since 1.2.0
  */
@@ -49,7 +49,6 @@ public class HTMLSanitizerPerformance_Test extends AbstractWComponentTestCase {
 			+ "justo sapien.</p></div><ul onclick='alert();'><li class='dot'>one</li><li class='dot'>two</li>"
 			+ "<li class='dot'>three</li><li class='dot'>for</li><li class='dot'>five</li></ul>";
 
-
 	@Test
 	public void testSanitizerPerformance2() {
 		final int fewLoops = 20;
@@ -61,20 +60,19 @@ public class HTMLSanitizerPerformance_Test extends AbstractWComponentTestCase {
 		long fewLoopTime = fewLoopTotalTime / fewLoops;
 		long manyLoopTime = manyLoopTotalTime / manyLoops;
 
-
 		LOG.info(String.valueOf(fewLoops) + " runs of sanitizer time: " + (fewLoopTotalTime / 1000000000.0) + "s");
 		LOG.info(String.valueOf(manyLoops) + " runs of sanitizer time: " + (manyLoopTotalTime / 1000000000.0) + "s");
 
 		LOG.info(String.valueOf(fewLoops) + " runs of sanitizer time: " + (fewLoopTime / 1000000.0) + "ms per run");
 		LOG.info(String.valueOf(manyLoops) + " runs of sanitizer time: " + (manyLoopTime / 1000000.0) + "ms per run");
 
-		Assert.assertTrue("Sanitizing many entries should not exceed sanitizing few",
-				manyLoopTime <= fewLoopTime);
-	}
+		assertLessThan("Sanitizing many entries should not exceed sanitizing few", manyLoopTime, fewLoopTime);
 
+	}
 
 	/**
 	 * run many sanitized getData calls.
+	 *
 	 * @param count the number of loops to run
 	 * @return the time taken to run all the runnables.
 	 */

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -69,6 +69,8 @@
 						<configuration>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
 							<shadedClassifierName>jar-with-dependencies</shadedClassifierName>
+							<!-- The reduced pom impacts the use of the main attached jar as it removes all dependencies -->
+							<createDependencyReducedPom>false</createDependencyReducedPom>
 							<filters>
 								<filter>
 									<artifact>*:*</artifact>

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -61,42 +61,51 @@
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
 			<version>1.9.0</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
+		<!-- Test dependencies -->
 		<dependency>
-			<scope>test</scope>
 			<groupId>com.github.bordertech.wcomponents</groupId>
 			<artifactId>wcomponents-test-lib</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<scope>test</scope>
 			<groupId>com.github.bordertech.wcomponents</groupId>
 			<artifactId>wcomponents-theme</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<dependency>
-			<scope>test</scope>
 			<groupId>com.github.bordertech.wcomponents</groupId>
 			<artifactId>wcomponents-xslt</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- JSR107 Caching provider. -->
 		<dependency>
-			<scope>test</scope>
 			<groupId>org.ehcache</groupId>
 			<artifactId>ehcache</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<!-- JAXB runtime for cache provider -->
 		<dependency>
-			<scope>test</scope>
 			<groupId>org.glassfish.jaxb</groupId>
 			<artifactId>jaxb-runtime</artifactId>
+			<scope>test</scope>
 		</dependency>
 
+		<!-- Not ideal but this needs to be after the jetty dependency in the pom so Jetty pickups its own servlet-api first in the test classpath -->
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -61,8 +61,8 @@
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
 			<version>1.9.0</version>
-			<!-- Fix convergence -->
 			<exclusions>
+				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -52,25 +52,23 @@
 			<version>${jetty.version}</version>
 		</dependency>
 
+		<!-- Test dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
-
 		<dependency>
-			<scope>test</scope>
 			<groupId>com.github.bordertech.wcomponents</groupId>
 			<artifactId>wcomponents-theme</artifactId>
 			<version>${project.version}</version>
-		</dependency>
-
-		<dependency>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.github.bordertech.wcomponents</groupId>
 			<artifactId>wcomponents-xslt</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
 		</dependency>
-
 
 	</dependencies>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -40,6 +40,7 @@
 	</build>
 
 	<dependencies>
+
 		<dependency>
 			<groupId>com.github.bordertech.wcomponents</groupId>
 			<artifactId>wcomponents-core</artifactId>
@@ -56,6 +57,17 @@
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
 			<version>${selenium.version}</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
@@ -68,12 +80,77 @@
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
 			<version>5.9.2</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-compress</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents.client5</groupId>
+					<artifactId>httpclient5</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.guava</groupId>
+					<artifactId>guava</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>
 			<groupId>xmlunit</groupId>
 			<artifactId>xmlunit</artifactId>
 			<version>1.6</version>
+		</dependency>
+
+		<!-- Force versions to avoid convergence errors -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>1.27.1</version>
+			<!-- Fix convergence -->
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-lang3</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-io</groupId>
+					<artifactId>commons-io</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+			<version>1.17.1</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>33.3.1-jre</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.errorprone</groupId>
+					<artifactId>error_prone_annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -87,6 +87,10 @@
 					<artifactId>slf4j-api</artifactId>
 				</exclusion>
 				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>jcl-over-slf4j</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.apache.commons</groupId>
 					<artifactId>commons-compress</artifactId>
 				</exclusion>


### PR DESCRIPTION
### Enhancements
* Update project dependencies to current versions
* Fix convergent dependencies by using excludes and adding the required dependency directly. Only using  DependencyManagement in the parent pom is not reliable for library projects.
* Update velocity from 2.3 to 2.4. Refer to changelog below for 1.5.35 on backward compatability to version 1.5 and 1.7.
* Use jcl-over-slf4j from SLF4J to provide the commons-logging API.
  * Libraries used by WComponents use SLF4J and WComponents currently uses common-loggings which routes to SLF4J. SLF4J recommend using their jcl-over-slf4j dependency to direct any libraries using commons-logging to SLF4J to avoid classpath issues (Refer to https://www.slf4j.org/legacy.html#jclOverSLF4J).
  * Exclude commons-logging from transitive dependencies to make sure jcl-over-slf4j is used instead to direct JCL to SLF4J.
  * jcl-over-slf4j can be used until WComponents is refactored to use SLF4J.

### Bug Fixes
* The latest version of the shade plugin used to create the examples lde dependency jar has changed how it handles the reduced pom files. The reduced pom removes all the dependencies which impacts the use of the main attached jar so its creation has been disabled.
* Improve performance unit test messaging and increase padding factors to help avoid intermittent fails.
