### PR TITLE
Update java dependencies and revert to commons-logging

### DIFF
--- a/.github/workflows/github-actions-build.yml
+++ b/.github/workflows/github-actions-build.yml
@@ -18,7 +18,7 @@ jobs:
         distribution: 'adopt'
 
     - name: Cache Maven Repo
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### API Changes
 ### Enhancements
+### Bug Fixes
+
+## 1.5.36
+
+### Enhancements
 * Update project dependencies to current versions
 * Fix convergent dependencies by using excludes and adding the required dependency directly. Only using
   DependencyManagement in the parent pom is not reliable for library projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### API Changes
 ### Enhancements
+* Revert to commons-logging instead of jcl-over-slf4j to allow projects to decide on how to handle logging.
+
 ### Bug Fixes
 
 ## 1.5.36

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@
 ### API Changes
 ### Enhancements
 * Revert to commons-logging instead of jcl-over-slf4j to allow projects to decide on how to handle logging.
+* Updated the following dependencies:
+  * wcomponents-core:
+    * commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0
+    * commons-fileupload:commons-fileupload from 1.5 to 1.6.0
+    * commons-io:commons-io from 2.17.0 to 2.19.0
+    * com.google.code.gson:gson from 2.11.0 to 2.13.1
+    * com.google.errorprone:error_prone_annotations from 2.33.0 to 2.39.0
+    * org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0
+    * org.apache.httpcomponents.client5:httpclient5 from 5.4 to 5.5
+    * org.apache.httpcomponents.core5:httpcore5 from 5.3 to 5.3.4
+    * org.apache.tika:tika-core from 2.9.2 to 2.9.4
+    * org.apache.velocity:velocity-engine-core from 2.4 to 2.4.1
+    * org.apache.xmlgraphics:batik-css from 1.17 to 1.19
+    * org.slf4j:slf4j-api from 2.0.16 to 2.0.17
+    * xerces:xercesImpl from 2.12.2 to 2.12.1 (version 2.12.2 has critical vulnerability)
+  * wcomponents-examples:
+    * commons-validator:commons-validator from 1.9.0 to 1.10.0
+  * wcomponents-test-lib:
+    * io.github.bonigarcia:webdrivermanager from 5.9.2 to 6.1.0
+    * commons-codec:commons-codec from 1.17.1 to 1.18.0
+    * com.google.guava:guava from 33.3.1-jre to 33.4.8-jre
 
 ### Bug Fixes
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.5.36</version>
+	<version>1.5.37-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 
@@ -47,7 +47,7 @@
 		<url>https://github.com/bordertech/wcomponents</url>
 		<connection>scm:git:https://github.com/bordertech/wcomponents.git</connection>
 		<developerConnection>scm:git:https://github.com/bordertech/wcomponents.git</developerConnection>
-		<tag>wcomponents-parent-1.5.36</tag>
+		<tag>wcomponents-1.0.0</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.5.36-SNAPSHOT</version>
+	<version>1.5.36</version>
 
 	<packaging>pom</packaging>
 
@@ -47,7 +47,7 @@
 		<url>https://github.com/bordertech/wcomponents</url>
 		<connection>scm:git:https://github.com/bordertech/wcomponents.git</connection>
 		<developerConnection>scm:git:https://github.com/bordertech/wcomponents.git</developerConnection>
-		<tag>wcomponents-1.0.0</tag>
+		<tag>wcomponents-parent-1.5.36</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 	<properties>
 		<jetty.version>8.1.16.v20140903</jetty.version>
-		<slf4j.version>2.0.16</slf4j.version>
+		<slf4j.version>2.0.17</slf4j.version>
 		<bt.qa.skip>false</bt.qa.skip>
 		<bt.convergence.check.fail>true</bt.convergence.check.fail>
 		<!-- Report Vulnerabilities. -->

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -44,13 +44,6 @@
 			<artifactId>jaxb-runtime</artifactId>
 		</dependency>
 
-		<!-- SLF4J implementation. -->
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-			<version>${slf4j.version}</version>
-		</dependency>
-
 	</dependencies>
 
 </project>

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -119,8 +119,8 @@
 			<groupId>commons-configuration</groupId>
 			<artifactId>commons-configuration</artifactId>
 			<version>1.10</version>
+			<!-- Fix convergence -->
 			<exclusions>
-				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
@@ -132,8 +132,8 @@
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
 			<version>1.9.4</version>
+			<!-- Fix convergence -->
 			<exclusions>
-				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
@@ -270,12 +270,11 @@
 			<artifactId>batik-css</artifactId>
 			<version>1.17</version>
 			<exclusions>
-				<!-- Exclude to use jcl-over-slf4j -->
+				<!-- Fix convergence -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>
 				</exclusion>
-				<!-- Fix convergence -->
 				<exclusion>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
@@ -320,22 +319,17 @@
 			</exclusions>
 		</dependency>
 
-		<!-- Libraries used by WComponents use SLF4J and WComponents currently uses common-loggings which routes to SLF4J.
-		SLF4J recommend using their jcl-over-slf4j dependency to direct any libraries using commons-logging to SLF4J
-		to avoid classpath issues (Refer to https://www.slf4j.org/legacy.html#jclOverSLF4J).
-		This can be used until WComponents is refactored to use SLF4J. -->
+		<!-- Force versions to fix convergence -->
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>jcl-over-slf4j</artifactId>
-			<version>${slf4j.version}</version>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.3.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j.version}</version>
 		</dependency>
-
-		<!-- Force versions to fix convergence -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -131,7 +131,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
-			<version>1.9.4</version>
+			<version>1.11.0</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>
@@ -144,7 +144,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.5</version>
+			<version>1.6.0</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>
@@ -190,7 +190,7 @@
 		<dependency>
 			<groupId>org.apache.velocity</groupId>
 			<artifactId>velocity-engine-core</artifactId>
-			<version>2.4</version>
+			<version>2.4.1</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>
@@ -214,7 +214,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.11.0</version>
+			<version>2.13.1</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.google.errorprone</groupId>
@@ -257,6 +257,10 @@
 					<groupId>net.sourceforge.htmlunit</groupId>
 					<artifactId>neko-htmlunit</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>xerces</groupId>
+					<artifactId>xercesImpl</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<!-- Neko-htmlunit had a package rename as of 3.X.X and cannot be picked up until latest Antisamy can be used -->
@@ -268,7 +272,7 @@
 		<dependency>
 			<groupId>org.apache.xmlgraphics</groupId>
 			<artifactId>batik-css</artifactId>
-			<version>1.17</version>
+			<version>1.19</version>
 			<exclusions>
 				<!-- Fix convergence -->
 				<exclusion>
@@ -282,10 +286,11 @@
 			</exclusions>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- Using version 2.12.1 as 2.12.2 has a critical vulnerability -->
 		<dependency>
 			<groupId>xerces</groupId>
 			<artifactId>xercesImpl</artifactId>
-			<version>2.12.2</version>
+			<version>2.12.1</version>
 			<scope>runtime</scope>
 		</dependency>
 
@@ -305,7 +310,7 @@
 		<dependency>
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
-			<version>2.9.2</version>
+			<version>2.9.4</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>
@@ -333,22 +338,22 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.17.0</version>
+			<version>3.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.17.0</version>
+			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.errorprone</groupId>
 			<artifactId>error_prone_annotations</artifactId>
-			<version>2.33.0</version>
+			<version>2.39.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
-			<version>5.4</version>
+			<version>5.5</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>
@@ -359,7 +364,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents.core5</groupId>
 			<artifactId>httpcore5</artifactId>
-			<version>5.3</version>
+			<version>5.3.4</version>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -52,6 +52,14 @@
 			<artifactId>wcomponents-lde</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+
+		<!-- SLF4J implementation for basic logging. -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>${slf4j.version}</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -61,8 +61,8 @@
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
 			<version>1.9.0</version>
+			<!-- Fix convergence -->
 			<exclusions>
-				<!-- Exclude to use jcl-over-slf4j -->
 				<exclusion>
 					<groupId>commons-logging</groupId>
 					<artifactId>commons-logging</artifactId>

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -60,7 +60,7 @@
 		<dependency>
 			<groupId>commons-validator</groupId>
 			<artifactId>commons-validator</artifactId>
-			<version>1.9.0</version>
+			<version>1.10.0</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>

--- a/wcomponents-i18n/pom.xml
+++ b/wcomponents-i18n/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-i18n/pom.xml
+++ b/wcomponents-i18n/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>io.github.bonigarcia</groupId>
 			<artifactId>webdrivermanager</artifactId>
-			<version>5.9.2</version>
+			<version>6.1.0</version>
 			<!-- Fix convergence -->
 			<exclusions>
 				<exclusion>
@@ -109,6 +109,14 @@
 				<exclusion>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.java.dev.jna</groupId>
+					<artifactId>jna</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -143,18 +151,23 @@
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>
-			<version>1.17.1</version>
+			<version>1.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>33.3.1-jre</version>
+			<version>33.4.8-jre</version>
 			<exclusions>
 				<exclusion>
 					<groupId>com.google.errorprone</groupId>
 					<artifactId>error_prone_annotations</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>net.java.dev.jna</groupId>
+			<artifactId>jna</artifactId>
+			<version>5.17.0</version>
 		</dependency>
 
 		<dependency>

--- a/wcomponents-theme/package.json
+++ b/wcomponents-theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wcomponents-theme",
-	"version": "1.5.36-SNAPSHOT",
+	"version": "1.5.37-SNAPSHOT",
 	"description": "Client side code for WComponents UI tool kit.",
 	"private": true,
 	"com_github_bordertech": {

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/wcomponents-xslt/pom.xml
+++ b/wcomponents-xslt/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36-SNAPSHOT</version>
+		<version>1.5.36</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/wcomponents-xslt/pom.xml
+++ b/wcomponents-xslt/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.36</version>
+		<version>1.5.37-SNAPSHOT</version>
 	</parent>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
- Revert to commons-logging instead of jcl-over-slf4j to allow projects to decide on how to handle logging.
- Update project dependencies to the latest versions