### PR TITLE
Release 1.5.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### API Changes
 ### Enhancements
+### Bug Fixes
+
+## 1.5.37
+
+### Enhancements
 * Revert to commons-logging instead of jcl-over-slf4j to allow projects to decide on how to handle logging.
 * Updated the following dependencies:
   * wcomponents-core:
@@ -26,8 +31,6 @@
     * io.github.bonigarcia:webdrivermanager from 5.9.2 to 6.1.0
     * commons-codec:commons-codec from 1.17.1 to 1.18.0
     * com.google.guava:guava from 33.3.1-jre to 33.4.8-jre
-
-### Bug Fixes
 
 ## 1.5.36
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,12 @@
 		<cveValidForHours>168</cveValidForHours>
 
 		<dependency-check.skip>true</dependency-check.skip>
+
+		<!-- OSSRH has been sunsetted so this is the API to use until publishing directly to Central Publisher Portal. -->
+		<!-- After running the maven release execute the following REST command with namespace com.github.bordertech to push the artifacts from OSSRH staging to Central Publisher Portal. -->
+		<!-- Use the same userid and token generated in the portal for the settings.xml file when prompted -->
+		<!-- https://ossrh-staging-api.central.sonatype.com/swagger-ui/#/default/manual_upload_default_repository -->
+		<!-- Refer to https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#ensuring-deployment-visibility-in-the-central-publisher-portal -->
 		<stagingBaseUrl>https://ossrh-staging-api.central.sonatype.com/</stagingBaseUrl>
 
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.5.37</version>
+	<version>1.5.38-SNAPSHOT</version>
 
 	<packaging>pom</packaging>
 
@@ -51,7 +51,7 @@
 		<url>https://github.com/bordertech/wcomponents</url>
 		<connection>scm:git:https://github.com/bordertech/wcomponents.git</connection>
 		<developerConnection>scm:git:https://github.com/bordertech/wcomponents.git</developerConnection>
-		<tag>wcomponents-parent-1.5.37</tag>
+		<tag>wcomponents-1.0.0</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<cveValidForHours>168</cveValidForHours>
 
 		<dependency-check.skip>true</dependency-check.skip>
+		<stagingBaseUrl>https://ossrh-staging-api.central.sonatype.com/</stagingBaseUrl>
 
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>com.github.bordertech.wcomponents</groupId>
 	<artifactId>wcomponents-parent</artifactId>
-	<version>1.5.37-SNAPSHOT</version>
+	<version>1.5.37</version>
 
 	<packaging>pom</packaging>
 
@@ -51,7 +51,7 @@
 		<url>https://github.com/bordertech/wcomponents</url>
 		<connection>scm:git:https://github.com/bordertech/wcomponents.git</connection>
 		<developerConnection>scm:git:https://github.com/bordertech/wcomponents.git</developerConnection>
-		<tag>wcomponents-1.0.0</tag>
+		<tag>wcomponents-parent-1.5.37</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,9 @@
 		<failBuildOnCVSS>11</failBuildOnCVSS>
 		<!-- Update every 168 hours (7 days) -->
 		<cveValidForHours>168</cveValidForHours>
+
+		<dependency-check.skip>true</dependency-check.skip>
+
 	</properties>
 
 	<licenses>

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-bundle/pom.xml
+++ b/wcomponents-bundle/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-core/pom.xml
+++ b/wcomponents-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples-lde/pom.xml
+++ b/wcomponents-examples-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-examples/pom.xml
+++ b/wcomponents-examples/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-i18n/pom.xml
+++ b/wcomponents-i18n/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-i18n/pom.xml
+++ b/wcomponents-i18n/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-lde/pom.xml
+++ b/wcomponents-lde/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-test-lib/pom.xml
+++ b/wcomponents-test-lib/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/wcomponents-theme/package.json
+++ b/wcomponents-theme/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wcomponents-theme",
-	"version": "1.5.37-SNAPSHOT",
+	"version": "1.5.38-SNAPSHOT",
 	"description": "Client side code for WComponents UI tool kit.",
 	"private": true,
 	"com_github_bordertech": {

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/wcomponents-theme/pom.xml
+++ b/wcomponents-theme/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/wcomponents-xslt/pom.xml
+++ b/wcomponents-xslt/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37</version>
+		<version>1.5.38-SNAPSHOT</version>
 	</parent>
 
 	<packaging>jar</packaging>

--- a/wcomponents-xslt/pom.xml
+++ b/wcomponents-xslt/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.github.bordertech.wcomponents</groupId>
 		<artifactId>wcomponents-parent</artifactId>
-		<version>1.5.37-SNAPSHOT</version>
+		<version>1.5.37</version>
 	</parent>
 
 	<packaging>jar</packaging>


### PR DESCRIPTION
* Revert to commons-logging instead of jcl-over-slf4j to allow projects to decide on how to handle logging.
* Updated the following dependencies:
  * wcomponents-core:
    * commons-beanutils:commons-beanutils from 1.9.4 to 1.11.0
    * commons-fileupload:commons-fileupload from 1.5 to 1.6.0
    * commons-io:commons-io from 2.17.0 to 2.19.0
    * com.google.code.gson:gson from 2.11.0 to 2.13.1
    * com.google.errorprone:error_prone_annotations from 2.33.0 to 2.39.0
    * org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0
    * org.apache.httpcomponents.client5:httpclient5 from 5.4 to 5.5
    * org.apache.httpcomponents.core5:httpcore5 from 5.3 to 5.3.4
    * org.apache.tika:tika-core from 2.9.2 to 2.9.4
    * org.apache.velocity:velocity-engine-core from 2.4 to 2.4.1
    * org.apache.xmlgraphics:batik-css from 1.17 to 1.19
    * org.slf4j:slf4j-api from 2.0.16 to 2.0.17
    * xerces:xercesImpl from 2.12.2 to 2.12.1 (version 2.12.2 has critical vulnerability)
  * wcomponents-examples:
    * commons-validator:commons-validator from 1.9.0 to 1.10.0
  * wcomponents-test-lib:
    * io.github.bonigarcia:webdrivermanager from 5.9.2 to 6.1.0
    * commons-codec:commons-codec from 1.17.1 to 1.18.0
    * com.google.guava:guava from 33.3.1-jre to 33.4.8-jre